### PR TITLE
Help container feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Check the [example](#usage)! This package was built to support the [cookiecutter
 
     `ContainerArgumentParser` adds the `--docker`, `--singularity` and `--volumes` arguments to the options namespace. This parser only prints the required toil arguments when using `--help`. However, the full list of toil rocketry is printed with `--help-toil`. If you don't need the container options but want to use `--help-toil` use `ToilShortArgumentParser`.
 
-       whalesay.py --help
+       whalesay.py --help-container
 
            usage: whalesay [-h] [-v] [--help-toil] [TOIL OPTIONAL ARGS] jobStore
 
             optional arguments:
             -h, --help            show this help message and exit
-            --help-toil           print help with full list of Toil arguments and exit
+            --help-toil           show help with toil arguments and exit
 
             container arguments:
             --docker              name/path of the docker image available in daemon

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Check the [example](#usage)! This package was built to support the [cookiecutter
             optional arguments:
             -h, --help            show this help message and exit
             --help-toil           show help with toil arguments and exit
+            --help-container      show help with container arguments and exit
 
             container arguments:
             --docker              name/path of the docker image available in daemon

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -14,7 +14,7 @@ from .utils import Capturing
 
 
 def check_help_toil(parser):
-    with Capturing() as without_toil:
+    with Capturing() as plain:
         try:
             parser.parse_args(["--help"])
         except SystemExit:
@@ -26,17 +26,28 @@ def check_help_toil(parser):
         except SystemExit:
             pass
 
+    plain = "\n".join(plain)
     with_toil = "\n".join(with_toil)
-    without_toil = "\n".join(without_toil)
 
     # by default toil options shouldn't be printed
-    assert "toil core options" not in without_toil
-    assert "TOIL OPTIONAL ARGS" in without_toil
-    assert "toil arguments" in without_toil
+    assert "toil core options" not in plain
+    assert "toil arguments" in plain
 
     # check that toil options were added by default
-    assert "toil core options" not in without_toil
+    assert "toil core options" not in plain
     assert "toil core options" in with_toil
+
+    # test container arguments
+    if isinstance(parser, parsers.ContainerArgumentParser):
+        with Capturing() as with_container:
+            try:
+                parser.parse_args(["--help-container"])
+            except SystemExit:
+                pass
+
+        with_container = "\n".join(with_container)
+        assert "container arguments:" not in plain
+        assert "container arguments:" in with_container
 
 
 def assert_parser_volumes(image_flag, image, tmpdir):

--- a/toil_container/containers.py
+++ b/toil_container/containers.py
@@ -114,10 +114,7 @@ def singularity_call(
         pass
 
     if remove_tmp_dir:
-        try:
-            shutil.rmtree(work_dir)
-        except:  # pylint: disable=W0702
-            pass
+        shutil.rmtree(work_dir, ignore_errors=True)
 
     if error:
         raise get_container_error(error)
@@ -198,11 +195,8 @@ def docker_call(
     except expected_errors as error:
         pass
 
-    if remove_tmp_dir:
-        try:
-            shutil.rmtree(work_dir)
-        except:  # pylint: disable=W0702
-            pass
+    if remove_tmp_dir and work_dir:
+        shutil.rmtree(work_dir, ignore_errors=True)
 
     if error:
         _remove_docker_container(container_name)

--- a/toil_container/parsers.py
+++ b/toil_container/parsers.py
@@ -101,6 +101,8 @@ class ToilShortArgumentParser(ToilBaseArgumentParser):
         if is_toil_group or "Logging Options" in action_group.title:
             return not self.show_toil_groups
 
+        return False
+
     def get_help_groups(self):
         """Decide whether to show toil options or not."""
         action_groups = []

--- a/toil_container/parsers.py
+++ b/toil_container/parsers.py
@@ -96,7 +96,7 @@ class ToilShortArgumentParser(ToilBaseArgumentParser):
         return getattr(self, SHOW_TOILGROUPS_PROPERTY, False)
 
     def hide_action_group(self, action_group):
-        """Return True if group shouldn't be showed."""
+        """Determine if an action group should be hidden."""
         is_toil_group = action_group.title.startswith("toil")
         if is_toil_group or "Logging Options" in action_group.title:
             return not self.show_toil_groups


### PR DESCRIPTION
Hide container options by default and add `--help-container` to display them.

- [x] 🚀 &nbsp; New feature
- [x] 🔧 &nbsp; Code refactor
- [x] 📘 &nbsp; I have updated the documentation accordingly
- [x] ✅ &nbsp; I have added tests to cover my changes

See example:

```
usage: toil_disambiguate [-h] [-v] [--help-toil] [--help-container]
                         --input_data INPUT_DATA [INPUT_DATA ...]
                         --sample_name SAMPLE_NAME --reference_a REFERENCE_A
                         --reference_b REFERENCE_B
                         [--max_cores_usage MAX_CORES_USAGE]
                         [--max_memory_usage MAX_MEMORY_USAGE]
                         [--keep_intermediates]
                         jobStore

toil_disambiguate pipeline

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  --help-toil           show help with toil arguments and exit
  --help-container      show help with container arguments and exit

pipeline arguments:
  --outdir OUTDIR       path to output directory (default: None)
  ...
 
toil arguments:
  jobStore              the location of the job store for the workflow. See
                        --help-toil for more toil options and information
                        [REQUIRED]
```