### PR TITLE
remove subprocess32 as main dependency

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -18,7 +18,6 @@
     "install_requires": [
         "Click>=6.7",
         "docker==2.5.1",
-        "subprocess32>=3.2.7",
         "toil>=3.12.0"
     ],
     "keywords": [


### PR DESCRIPTION
remove subprocess32 as main dependency as is a dependency of toil already, and is giving a conflict version error.

`pkg_resources.ContextualVersionConflict: (subprocess32 3.2.7 (/Users/arangooj/.virtualenvs/toil_hello/lib/python2.7/site-packages), Requirement.parse('subprocess32==3.5.0rc1'), set(['toil']))`

- [x ] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
